### PR TITLE
Finding the best UTXOS for different utxo order

### DIFF
--- a/NBXplorer.Tests/CoinSelectionHelpers.cs
+++ b/NBXplorer.Tests/CoinSelectionHelpers.cs
@@ -1,0 +1,640 @@
+using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using NBXplorer;
+using NBXplorer.Models;
+using Xunit;
+
+public class CoinSelectionHelpersTests
+{
+	public static List<IMoney> GetValues(List<UTXO> utxos)
+	{
+		return utxos.Select(u => u.Value).ToList();
+	}
+
+	/// <summary>
+	/// General tests for SelectCoins
+	/// </summary>
+	[Fact]
+	public void SelectCoins_ShouldReturnEmptyList_WhenUTXOsListIsEmpty()
+	{
+		// Arrange
+		int limit = 3;
+		long amount = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(new List<UTXO>(), limit, amount);
+
+		// Assert
+		Assert.Empty(result);
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_NoChangeless_OneUtxoCoversAll()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(10) },
+		};
+		int limit = 3;
+		long amount = 9;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+
+		// Assert
+		Assert.Equal(new[] { new Money(10) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_Changeless_OneUtxoCoversAll()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(8) },
+		};
+		int limit = 3;
+		long amount = 9;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(8) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_NoChangeless_NoUtxoCoversTheAmount()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(5) },
+		};
+		int limit = 3;
+		long amount = 9;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+
+		// Assert
+		Assert.Empty(GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_Changeless_NoUtxoCoversTheAmount()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(5) },
+		};
+		int limit = 3;
+		long amount = 9;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Empty(GetValues(result));
+	}
+
+	/// <summary>
+	/// Tests for SelectCoins when UTXOs are provided in ascending order
+	/// </summary>
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_NoChangeless_WhenUTXOsListHasSufficientValuesOnFirstIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(2) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(6) }
+		};
+		int limit = 3;
+		long amount = 9;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+
+		// Assert
+		Assert.Equal(new[] { new Money(1), new Money(2), new Money(6) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_NoChangeless_WhenUTXOsListHasSufficientValuesOnSecondIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(2) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(5) }
+		};
+		int limit = 3;
+		long amount = 9;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+
+		// Assert
+		Assert.Equal(new[] { new Money(1), new Money(5), new Money(5) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_NoChangeless_WhenUTXOsListHasSufficientValuesOnThirdIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(2) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(5) }
+		};
+		int limit = 3;
+		long amount = 12;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+
+		// Assert
+		Assert.Equal(new[] { new Money(5), new Money(5), new Money(5) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_NoChangeless_WhenUTXOsListHasSufficientValuesOnTheNIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(2) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(10) }
+		};
+		int limit = 3;
+		long amount = 20;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+
+		// Assert
+		Assert.Equal(new[] { new Money(5), new Money(5), new Money(10) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_Changeless_InsideToleranceAbove_WhenUTXOsListHasSufficientValuesOnFirstIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(2) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(5) }
+		};
+		int limit = 3;
+		long amount = 7;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(1), new Money(2), new Money(5) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_Changeless_InsideToleranceAbove_WhenUTXOsListHasSufficientValuesOnSecondIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(2) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(5) }
+		};
+		int limit = 3;
+		long amount = 10;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(1), new Money(5), new Money(5) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_Changeless_InsideToleranceAbove_WhenUTXOsListHasSufficientValuesOnThirdIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(2) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(5) }
+		};
+		int limit = 3;
+		long amount = 14;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(5), new Money(5), new Money(5) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_Changeless_InsideToleranceAbove_WhenUTXOsListHasSufficientValuesOnTheNIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(2) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(10) }
+		};
+		int limit = 3;
+		long amount = 19;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(5), new Money(5), new Money(10) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_Changeless_InsideToleranceBelow_WhenUTXOsListHasSufficientValuesOnFirstIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(2) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(5) }
+		};
+		int limit = 3;
+		long amount = 9;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(1), new Money(2), new Money(5) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_Changeless_InsideToleranceBelow_WhenUTXOsListHasSufficientValuesOnSecondIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(2) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(5) }
+		};
+		int limit = 3;
+		long amount = 12;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(1), new Money(5), new Money(5) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_Changeless_InsideToleranceBelow_WhenUTXOsListHasSufficientValuesOnThirdIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(2) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(5) }
+		};
+		int limit = 3;
+		long amount = 16;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(5), new Money(5), new Money(5) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_Changeless_InsideToleranceBelow_WhenUTXOsListHasSufficientValuesOnTheNIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(2) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(10) }
+		};
+		int limit = 3;
+		long amount = 21;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(5), new Money(5), new Money(10) }, GetValues(result));
+	}
+
+	/// <summary>
+	/// Tests for SelectCoins when UTXOs are provided in descending order
+	/// </summary>
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_BiggestFirst_NoChangeless_WhenUTXOsListHasSufficientValues()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(6) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(2) },
+			new UTXO { Value = new Money(1) }
+		};
+		int limit = 3;
+		long amount = 9;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+
+		// Assert
+		Assert.Equal(new[] { new Money(6), new Money(3) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_BiggestFirst_Changeless_InsideToleranceAbove_WhenUTXOsListHasSufficientValues()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(2) },
+			new UTXO { Value = new Money(1) }
+		};
+		int limit = 3;
+		long amount = 7;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(5), new Money(3) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_BiggestFirst_Changeless_InsideToleranceBelow_WhenUTXOsListHasSufficientValues()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(4) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(1) }
+		};
+		int limit = 3;
+		long amount = 9;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(4), new Money(3), new Money(1) }, GetValues(result));
+	}
+
+	/// <summary>
+	/// Tests for SelectCoins when UTXOs are provided in closest to amount order
+	/// </summary>
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_TwoUtxosCoversAll()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(5) },
+		};
+		int limit = 3;
+		long amount = 9;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+
+		// Assert
+		Assert.Equal(new[] { new Money(5), new Money(5) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_ClosestFirst_NoChangeless_WhenUTXOsListHasSufficientValues()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(6) },
+			new UTXO { Value = new Money(4) },
+			new UTXO { Value = new Money(7) },
+			new UTXO { Value = new Money(3) }
+		};
+		int limit = 3;
+		long amount = 14;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
+
+		// Assert
+		Assert.Equal(new[] { new Money(5), new Money(6), new Money(4) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_ClosestFirst_Changeless_InsideToleranceAbove_WhenUTXOsListHasSufficientValuesOnSecondIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(2) },
+			new UTXO { Value = new Money(4) },
+			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(6) }
+		};
+		int limit = 3;
+		long amount = 11;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(3), new Money(6), new Money(1) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_ClosestFirst_Changeless_InsideToleranceAbove_WhenUTXOsListHasSufficientValuesOnThirdIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(6) },
+			new UTXO { Value = new Money(4) },
+			new UTXO { Value = new Money(7) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(10) },
+		};
+		int limit = 3;
+		long amount = 20;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(6), new Money(10), new Money(3) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_ClosestFirst_Changeless_InsideToleranceAbove_WhenUTXOsListHasSufficientValuesOnTheNIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(6) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(7) },
+			new UTXO { Value = new Money(4) },
+			new UTXO { Value = new Money(8) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(9) }
+		};
+		int limit = 3;
+		long amount = 21;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(3), new Money(8), new Money(9) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_ClosestFirst_Changeless_InsideToleranceBelow_WhenUTXOsListHasSufficientValuesOnSecondIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(4) },
+			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(6) }
+		};
+		int limit = 3;
+		long amount = 9;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(3), new Money(6), new Money(1) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_ClosestFirst_Changeless_InsideToleranceBelow_WhenUTXOsListHasSufficientValuesOnThirdIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(6) },
+			new UTXO { Value = new Money(4) },
+			new UTXO { Value = new Money(7) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(10) },
+		};
+		int limit = 3;
+		long amount = 18;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(6), new Money(10), new Money(3) }, GetValues(result));
+	}
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_ClosestFirst_Changeless_InsideToleranceBelow_WhenUTXOsListHasSufficientValuesOnTheNIteration()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(6) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(7) },
+			new UTXO { Value = new Money(4) },
+			new UTXO { Value = new Money(8) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(9) }
+		};
+		int limit = 3;
+		long amount = 19;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(3), new Money(8), new Money(9) }, GetValues(result));
+	}
+}

--- a/NBXplorer.Tests/CoinSelectionHelpers.cs
+++ b/NBXplorer.Tests/CoinSelectionHelpers.cs
@@ -48,26 +48,6 @@ public class CoinSelectionHelpersTests
 	}
 
 	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_Changeless_InsideToleranceBelow_OneUtxoCoversAll()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(8) },
-		};
-		int limit = 3;
-		long amount = 9;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(8) }, GetValues(result));
-	}
-
-
-	[Fact]
 	public void SelectCoins_ShouldReturnSelectedCoins_Changeless_InsideToleranceAbove_OneUtxoCoversAll()
 	{
 		// Arrange
@@ -77,10 +57,9 @@ public class CoinSelectionHelpersTests
 		};
 		int limit = 3;
 		long amount = 7;
-		int tolerance = 10;
 
 		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
 
 		// Assert
 		Assert.Equal(new[] { new Money(8) }, GetValues(result));
@@ -114,10 +93,9 @@ public class CoinSelectionHelpersTests
 		};
 		int limit = 3;
 		long amount = 9;
-		int tolerance = 10;
 
 		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount);
 
 		// Assert
 		Assert.Empty(GetValues(result));
@@ -216,194 +194,6 @@ public class CoinSelectionHelpersTests
 		Assert.Equal(new[] { new Money(5), new Money(5), new Money(10) }, GetValues(result));
 	}
 
-	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_Changeless_InsideToleranceAbove_WhenUTXOsListHasSufficientValuesOnFirstIteration()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(1) },
-			new UTXO { Value = new Money(2) },
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(5) }
-		};
-		int limit = 3;
-		long amount = 7;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(1), new Money(2), new Money(5) }, GetValues(result));
-	}
-
-	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_Changeless_InsideToleranceAbove_WhenUTXOsListHasSufficientValuesOnSecondIteration()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(1) },
-			new UTXO { Value = new Money(2) },
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(5) },
-			new UTXO { Value = new Money(5) }
-		};
-		int limit = 3;
-		long amount = 10;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(1), new Money(5), new Money(5) }, GetValues(result));
-	}
-
-	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_Changeless_InsideToleranceAbove_WhenUTXOsListHasSufficientValuesOnThirdIteration()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(1) },
-			new UTXO { Value = new Money(2) },
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(5) },
-			new UTXO { Value = new Money(5) },
-			new UTXO { Value = new Money(5) }
-		};
-		int limit = 3;
-		long amount = 14;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(5), new Money(5), new Money(5) }, GetValues(result));
-	}
-
-	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_Changeless_InsideToleranceAbove_WhenUTXOsListHasSufficientValuesOnTheNIteration()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(1) },
-			new UTXO { Value = new Money(2) },
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(5) },
-			new UTXO { Value = new Money(5) },
-			new UTXO { Value = new Money(5) },
-			new UTXO { Value = new Money(10) }
-		};
-		int limit = 3;
-		long amount = 19;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(5), new Money(5), new Money(10) }, GetValues(result));
-	}
-
-	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_Changeless_InsideToleranceBelow_WhenUTXOsListHasSufficientValuesOnFirstIteration()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(1) },
-			new UTXO { Value = new Money(2) },
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(5) }
-		};
-		int limit = 3;
-		long amount = 9;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(1), new Money(2), new Money(5) }, GetValues(result));
-	}
-
-	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_Changeless_InsideToleranceBelow_WhenUTXOsListHasSufficientValuesOnSecondIteration()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(1) },
-			new UTXO { Value = new Money(2) },
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(5) },
-			new UTXO { Value = new Money(5) }
-		};
-		int limit = 3;
-		long amount = 12;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(1), new Money(5), new Money(5) }, GetValues(result));
-	}
-
-	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_Changeless_InsideToleranceBelow_WhenUTXOsListHasSufficientValuesOnThirdIteration()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(1) },
-			new UTXO { Value = new Money(2) },
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(5) },
-			new UTXO { Value = new Money(5) },
-			new UTXO { Value = new Money(5) }
-		};
-		int limit = 3;
-		long amount = 16;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(5), new Money(5), new Money(5) }, GetValues(result));
-	}
-
-	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_SmallestFirst_Changeless_InsideToleranceBelow_WhenUTXOsListHasSufficientValuesOnTheNIteration()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(1) },
-			new UTXO { Value = new Money(2) },
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(5) },
-			new UTXO { Value = new Money(5) },
-			new UTXO { Value = new Money(5) },
-			new UTXO { Value = new Money(10) }
-		};
-		int limit = 3;
-		long amount = 21;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(5), new Money(5), new Money(10) }, GetValues(result));
-	}
-
 	/// <summary>
 	/// Tests for SelectCoins when UTXOs are provided in descending order
 	/// </summary>
@@ -426,50 +216,6 @@ public class CoinSelectionHelpersTests
 
 		// Assert
 		Assert.Equal(new[] { new Money(6), new Money(3) }, GetValues(result));
-	}
-
-	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_BiggestFirst_Changeless_InsideToleranceAbove_WhenUTXOsListHasSufficientValues()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(5) },
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(2) },
-			new UTXO { Value = new Money(1) }
-		};
-		int limit = 3;
-		long amount = 7;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(5), new Money(3) }, GetValues(result));
-	}
-
-	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_BiggestFirst_Changeless_InsideToleranceBelow_WhenUTXOsListHasSufficientValues()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(4) },
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(1) },
-			new UTXO { Value = new Money(1) }
-		};
-		int limit = 3;
-		long amount = 9;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(4), new Money(3), new Money(1) }, GetValues(result));
 	}
 
 	/// <summary>
@@ -514,147 +260,5 @@ public class CoinSelectionHelpersTests
 
 		// Assert
 		Assert.Equal(new[] { new Money(5), new Money(6), new Money(4) }, GetValues(result));
-	}
-
-	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_ClosestFirst_Changeless_InsideToleranceAbove_WhenUTXOsListHasSufficientValuesOnSecondIteration()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(4) },
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(5) },
-			new UTXO { Value = new Money(7) },
-			new UTXO { Value = new Money(6) }
-		};
-		int limit = 3;
-		long amount = 11;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(4), new Money(3), new Money(5) }, GetValues(result));
-	}
-
-	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_ClosestFirst_Changeless_InsideToleranceAbove_WhenUTXOsListHasSufficientValuesOnThirdIteration()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(6) },
-			new UTXO { Value = new Money(4) },
-			new UTXO { Value = new Money(7) },
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(12) },
-		};
-		int limit = 3;
-		long amount = 20;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(6), new Money(12), new Money(3) }, GetValues(result));
-	}
-
-	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_ClosestFirst_Changeless_InsideToleranceAbove_WhenUTXOsListHasSufficientValuesOnTheNIteration()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(6) },
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(4) },
-			new UTXO { Value = new Money(12) },
-			new UTXO { Value = new Money(15) },
-			new UTXO { Value = new Money(16) }
-		};
-		int limit = 3;
-		long amount = 21;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(6), new Money(12), new Money(4) }, GetValues(result));
-	}
-
-	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_ClosestFirst_Changeless_InsideToleranceBelow_WhenUTXOsListHasSufficientValuesOnSecondIteration()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(1) },
-			new UTXO { Value = new Money(4) },
-			new UTXO { Value = new Money(1) },
-			new UTXO { Value = new Money(6) }
-		};
-		int limit = 3;
-		long amount = 9;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(3), new Money(1), new Money(4) }, GetValues(result));
-	}
-
-	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_ClosestFirst_Changeless_InsideToleranceBelow_WhenUTXOsListHasSufficientValuesOnThirdIteration()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(6) },
-			new UTXO { Value = new Money(4) },
-			new UTXO { Value = new Money(7) },
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(10) },
-		};
-		int limit = 3;
-		long amount = 18;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(6), new Money(4), new Money(7) }, GetValues(result));
-	}
-
-	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_ClosestFirst_Changeless_InsideToleranceBelow_WhenUTXOsListHasSufficientValuesOnTheNIteration()
-	{
-		// Arrange
-		var utxos = new List<UTXO>()
-		{
-			new UTXO { Value = new Money(6) },
-			new UTXO { Value = new Money(5) },
-			new UTXO { Value = new Money(7) },
-			new UTXO { Value = new Money(4) },
-			new UTXO { Value = new Money(8) },
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(9) }
-		};
-		int limit = 3;
-		long amount = 19;
-		int tolerance = 10;
-
-		// Act
-		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
-
-		// Assert
-		Assert.Equal(new[] { new Money(6), new Money(5), new Money(7) }, GetValues(result));
 	}
 }

--- a/NBXplorer.Tests/CoinSelectionHelpers.cs
+++ b/NBXplorer.Tests/CoinSelectionHelpers.cs
@@ -48,7 +48,7 @@ public class CoinSelectionHelpersTests
 	}
 
 	[Fact]
-	public void SelectCoins_ShouldReturnSelectedCoins_Changeless_OneUtxoCoversAll()
+	public void SelectCoins_ShouldReturnSelectedCoins_Changeless_InsideToleranceBelow_OneUtxoCoversAll()
 	{
 		// Arrange
 		var utxos = new List<UTXO>()
@@ -57,6 +57,26 @@ public class CoinSelectionHelpersTests
 		};
 		int limit = 3;
 		long amount = 9;
+		int tolerance = 10;
+
+		// Act
+		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
+
+		// Assert
+		Assert.Equal(new[] { new Money(8) }, GetValues(result));
+	}
+
+
+	[Fact]
+	public void SelectCoins_ShouldReturnSelectedCoins_Changeless_InsideToleranceAbove_OneUtxoCoversAll()
+	{
+		// Arrange
+		var utxos = new List<UTXO>()
+		{
+			new UTXO { Value = new Money(8) },
+		};
+		int limit = 3;
+		long amount = 7;
 		int tolerance = 10;
 
 		// Act
@@ -502,10 +522,10 @@ public class CoinSelectionHelpersTests
 		// Arrange
 		var utxos = new List<UTXO>()
 		{
-			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(2) },
 			new UTXO { Value = new Money(4) },
-			new UTXO { Value = new Money(1) },
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(5) },
+			new UTXO { Value = new Money(7) },
 			new UTXO { Value = new Money(6) }
 		};
 		int limit = 3;
@@ -516,7 +536,7 @@ public class CoinSelectionHelpersTests
 		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
 
 		// Assert
-		Assert.Equal(new[] { new Money(3), new Money(6), new Money(1) }, GetValues(result));
+		Assert.Equal(new[] { new Money(4), new Money(3), new Money(5) }, GetValues(result));
 	}
 
 	[Fact]
@@ -529,7 +549,7 @@ public class CoinSelectionHelpersTests
 			new UTXO { Value = new Money(4) },
 			new UTXO { Value = new Money(7) },
 			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(10) },
+			new UTXO { Value = new Money(12) },
 		};
 		int limit = 3;
 		long amount = 20;
@@ -539,7 +559,7 @@ public class CoinSelectionHelpersTests
 		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
 
 		// Assert
-		Assert.Equal(new[] { new Money(6), new Money(10), new Money(3) }, GetValues(result));
+		Assert.Equal(new[] { new Money(6), new Money(12), new Money(3) }, GetValues(result));
 	}
 
 	[Fact]
@@ -549,12 +569,12 @@ public class CoinSelectionHelpersTests
 		var utxos = new List<UTXO>()
 		{
 			new UTXO { Value = new Money(6) },
-			new UTXO { Value = new Money(5) },
-			new UTXO { Value = new Money(7) },
-			new UTXO { Value = new Money(4) },
-			new UTXO { Value = new Money(8) },
 			new UTXO { Value = new Money(3) },
-			new UTXO { Value = new Money(9) }
+			new UTXO { Value = new Money(3) },
+			new UTXO { Value = new Money(4) },
+			new UTXO { Value = new Money(12) },
+			new UTXO { Value = new Money(15) },
+			new UTXO { Value = new Money(16) }
 		};
 		int limit = 3;
 		long amount = 21;
@@ -564,7 +584,7 @@ public class CoinSelectionHelpersTests
 		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
 
 		// Assert
-		Assert.Equal(new[] { new Money(3), new Money(8), new Money(9) }, GetValues(result));
+		Assert.Equal(new[] { new Money(6), new Money(12), new Money(4) }, GetValues(result));
 	}
 
 	[Fact]
@@ -587,7 +607,7 @@ public class CoinSelectionHelpersTests
 		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
 
 		// Assert
-		Assert.Equal(new[] { new Money(3), new Money(6), new Money(1) }, GetValues(result));
+		Assert.Equal(new[] { new Money(3), new Money(1), new Money(4) }, GetValues(result));
 	}
 
 	[Fact]
@@ -610,7 +630,7 @@ public class CoinSelectionHelpersTests
 		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
 
 		// Assert
-		Assert.Equal(new[] { new Money(6), new Money(10), new Money(3) }, GetValues(result));
+		Assert.Equal(new[] { new Money(6), new Money(4), new Money(7) }, GetValues(result));
 	}
 
 	[Fact]
@@ -635,6 +655,6 @@ public class CoinSelectionHelpersTests
 		var result = CoinSelectionHelpers.SelectCoins(utxos, limit, amount, tolerance);
 
 		// Assert
-		Assert.Equal(new[] { new Money(3), new Money(8), new Money(9) }, GetValues(result));
+		Assert.Equal(new[] { new Money(6), new Money(5), new Money(7) }, GetValues(result));
 	}
 }

--- a/NBXplorer/CoinSelection/CoinSelectionHelpers.cs
+++ b/NBXplorer/CoinSelection/CoinSelectionHelpers.cs
@@ -35,27 +35,18 @@ public class Tolerance
 
 public static class CoinSelectionHelpers
 {
-	public static string OrderBy(CoinSelectionStrategy strategy, double number = 0)
+	public static string OrderBy(CoinSelectionStrategy strategy, long target = 0)
 	{
 		switch (strategy)
 		{
 			case CoinSelectionStrategy.BiggestFirst:
 				return "value DESC";
 			case CoinSelectionStrategy.ClosestToTargetFirst:
-				return $"abs(value - {number})";
+				return $"abs(value - {target})";
 			case CoinSelectionStrategy.SmallestFirst:
 			default:
 				return "value ASC";
 		}
-	}
-
-	public static double GetClosestTo(double? closestTo, long amount, int limit)
-	{
-		if (closestTo == null && limit == 0)
-		{
-			return 0;
-		}
-		return closestTo ?? Math.Truncate((double)(amount / limit));
 	}
 
 	public static List<UTXO> SelectCoins(List<UTXO> UTXOs, int limit, long amount, int tol = 0)

--- a/NBXplorer/CoinSelection/CoinSelectionHelpers.cs
+++ b/NBXplorer/CoinSelection/CoinSelectionHelpers.cs
@@ -5,34 +5,6 @@ using NBXplorer.Models;
 
 namespace NBXplorer;
 
-public class Tolerance
-{
-	public bool enabled = false;
-	private Money minTolerance = new Money(0);
-	private Money maxTolerance = new Money(0);
-
-	public Tolerance()
-	{
-	}
-
-	public Tolerance(long amount, int tolerance)
-	{
-		enabled = true;
-		minTolerance = new Money((long)Math.Floor(amount * (1 - (decimal)tolerance / 100)));
-		maxTolerance = new Money((long)Math.Ceiling(amount * (1 + (decimal)tolerance / 100)));
-	}
-
-	public bool Equals(Money amount)
-	{
-		if (enabled)
-		{
-			return minTolerance <= amount && maxTolerance >= amount;
-		}
-
-		return false;
-	}
-}
-
 public static class CoinSelectionHelpers
 {
 	public static string OrderBy(CoinSelectionStrategy strategy, long target = 0)
@@ -49,7 +21,7 @@ public static class CoinSelectionHelpers
 		}
 	}
 
-	public static List<UTXO> SelectCoins(List<UTXO> UTXOs, int limit, long amount, int tol = 0)
+	public static List<UTXO> SelectCoins(List<UTXO> UTXOs, int limit, long amount)
 	{
 		if (limit == 0)
 		{
@@ -58,12 +30,6 @@ public static class CoinSelectionHelpers
 
 		var utxosQueued = new Queue<UTXO>(UTXOs);
 		var targetAmount = new Money(amount);
-		var tolerance = new Tolerance();
-		if (tol > 0)
-		{
-			tolerance = new Tolerance(amount, tol);
-		}
-
 		var currentAmount = new Money(0);
 		var count = 0;
 		var retroCount = limit;
@@ -73,7 +39,7 @@ public static class CoinSelectionHelpers
 		{
 			var utxo = utxosQueued.Dequeue();
 			var utxoValue = (Money)utxo.Value;
-			if (!tolerance.enabled && currentAmount < targetAmount || tolerance.enabled && !tolerance.Equals(currentAmount))
+			if (currentAmount < targetAmount)
 			{
 				if (count >= limit && currentAmount < targetAmount)
 				{
@@ -94,7 +60,7 @@ public static class CoinSelectionHelpers
 			}
 		}
 
-		if (!tolerance.enabled && currentAmount < targetAmount || tolerance.enabled && !tolerance.Equals(currentAmount))
+		if (currentAmount < targetAmount)
 		{
 			selectedCoins.Clear();
 		}

--- a/NBXplorer/CoinSelection/CoinSelectionHelpers.cs
+++ b/NBXplorer/CoinSelection/CoinSelectionHelpers.cs
@@ -41,7 +41,7 @@ public static class CoinSelectionHelpers
 		{
 			case CoinSelectionStrategy.BiggestFirst:
 				return "value DESC";
-			case CoinSelectionStrategy.ClosestToAverageFirst:
+			case CoinSelectionStrategy.ClosestToFirst:
 				return $"abs(value - {number})";
 			case CoinSelectionStrategy.SmallestFirst:
 			default:

--- a/NBXplorer/CoinSelection/CoinSelectionHelpers.cs
+++ b/NBXplorer/CoinSelection/CoinSelectionHelpers.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using NBitcoin;
+using NBXplorer.Models;
+
+namespace NBXplorer;
+
+public class Tolerance
+{
+	public bool enabled = false;
+	private Money minTolerance = new Money(0);
+	private Money maxTolerance = new Money(0);
+
+	public Tolerance()
+	{
+	}
+
+	public Tolerance(long amount, int tolerance)
+	{
+		enabled = true;
+		minTolerance = new Money((long)Math.Floor(amount * (1 - (decimal)tolerance / 100)));
+		maxTolerance = new Money((long)Math.Ceiling(amount * (1 + (decimal)tolerance / 100)));
+	}
+
+	public bool Equals(Money amount)
+	{
+		if (enabled)
+		{
+			return minTolerance <= amount && maxTolerance >= amount;
+		}
+
+		return false;
+	}
+}
+
+public static class CoinSelectionHelpers
+{
+	public static string OrderBy(CoinSelectionStrategy strategy, double number = 0)
+	{
+		switch (strategy)
+		{
+			case CoinSelectionStrategy.BiggestFirst:
+				return "value DESC";
+			case CoinSelectionStrategy.ClosestToAverageFirst:
+				return $"abs(value - {number})";
+			case CoinSelectionStrategy.SmallestFirst:
+			default:
+				return "value ASC";
+		}
+	}
+
+	public static List<UTXO> SelectCoins(List<UTXO> UTXOs, int limit, long amount, int tol = 0)
+	{
+		var utxosQueued = new Queue<UTXO>(UTXOs);
+		var targetAmount = new Money(amount);
+		var tolerance = new Tolerance();
+		if (tol > 0)
+		{
+			tolerance = new Tolerance(amount, tol);
+		}
+
+		var currentAmount = new Money(0);
+		var count = 0;
+		var retroCount = limit;
+
+		var selectedCoins = new List<UTXO>();
+		while (utxosQueued.Count > 0)
+		{
+			var utxo = utxosQueued.Dequeue();
+			var utxoValue = (Money)utxo.Value;
+			if (currentAmount < targetAmount)
+			{
+				if (count >= limit && currentAmount < targetAmount)
+				{
+					retroCount = retroCount <= 0 ? limit - 1 : retroCount - 1;
+					var prevUtxo = selectedCoins[retroCount];
+					currentAmount -= (Money)prevUtxo.Value;
+					selectedCoins[retroCount] = utxo;
+					currentAmount += utxoValue;
+				}
+
+				if (count < limit)
+				{
+					var newAmount = currentAmount + utxoValue;
+					selectedCoins.Add(utxo);
+					currentAmount = newAmount;
+					count++;
+				}
+			}
+		}
+
+		if (!tolerance.enabled && currentAmount < targetAmount || tolerance.enabled && !tolerance.Equals(currentAmount))
+		{
+			selectedCoins.Clear();
+		}
+
+		return selectedCoins;
+	}
+}

--- a/NBXplorer/CoinSelection/CoinSelectionHelpers.cs
+++ b/NBXplorer/CoinSelection/CoinSelectionHelpers.cs
@@ -73,7 +73,7 @@ public static class CoinSelectionHelpers
 		{
 			var utxo = utxosQueued.Dequeue();
 			var utxoValue = (Money)utxo.Value;
-			if (currentAmount < targetAmount)
+			if (!tolerance.enabled && currentAmount < targetAmount || tolerance.enabled && !tolerance.Equals(currentAmount))
 			{
 				if (count >= limit && currentAmount < targetAmount)
 				{

--- a/NBXplorer/CoinSelection/CoinSelectionHelpers.cs
+++ b/NBXplorer/CoinSelection/CoinSelectionHelpers.cs
@@ -41,7 +41,7 @@ public static class CoinSelectionHelpers
 		{
 			case CoinSelectionStrategy.BiggestFirst:
 				return "value DESC";
-			case CoinSelectionStrategy.ClosestToFirst:
+			case CoinSelectionStrategy.ClosestToTargetFirst:
 				return $"abs(value - {number})";
 			case CoinSelectionStrategy.SmallestFirst:
 			default:
@@ -49,8 +49,22 @@ public static class CoinSelectionHelpers
 		}
 	}
 
+	public static double GetClosestTo(double? closestTo, long amount, int limit)
+	{
+		if (closestTo == null && limit == 0)
+		{
+			return 0;
+		}
+		return closestTo ?? Math.Truncate((double)(amount / limit));
+	}
+
 	public static List<UTXO> SelectCoins(List<UTXO> UTXOs, int limit, long amount, int tol = 0)
 	{
+		if (limit == 0)
+		{
+			return UTXOs;
+		}
+
 		var utxosQueued = new Queue<UTXO>(UTXOs);
 		var targetAmount = new Money(amount);
 		var tolerance = new Tolerance();

--- a/NBXplorer/CoinSelection/CoinSelectionStrategy.cs
+++ b/NBXplorer/CoinSelection/CoinSelectionStrategy.cs
@@ -1,0 +1,8 @@
+namespace NBXplorer;
+
+public enum CoinSelectionStrategy
+{
+	SmallestFirst,
+	BiggestFirst,
+	ClosestToAverageFirst
+}

--- a/NBXplorer/CoinSelection/CoinSelectionStrategy.cs
+++ b/NBXplorer/CoinSelection/CoinSelectionStrategy.cs
@@ -4,5 +4,5 @@ public enum CoinSelectionStrategy
 {
 	SmallestFirst,
 	BiggestFirst,
-	ClosestToAverageFirst
+	ClosestToFirst
 }

--- a/NBXplorer/CoinSelection/CoinSelectionStrategy.cs
+++ b/NBXplorer/CoinSelection/CoinSelectionStrategy.cs
@@ -4,5 +4,5 @@ public enum CoinSelectionStrategy
 {
 	SmallestFirst,
 	BiggestFirst,
-	ClosestToFirst
+	ClosestToTargetFirst
 }

--- a/NBXplorer/Controllers/CoinSelectionController.cs
+++ b/NBXplorer/Controllers/CoinSelectionController.cs
@@ -41,6 +41,7 @@ namespace NBXplorer.Controllers
 			[FromQuery(Name = "amount")] long amount,
 			[FromQuery(Name = "limit")] int limit = 50,
 			[FromQuery(Name = "tolerance")] int tolerance = 0,
+			[FromQuery(Name = "closestTo")] double? closestTo = null,
 			[FromQuery(Name = "strategy")] CoinSelectionStrategy strategy = CoinSelectionStrategy.SmallestFirst)
 		{
 			var trackedSource = GetTrackedSource(derivationScheme, address);
@@ -83,7 +84,7 @@ namespace NBXplorer.Controllers
 				DateTime tx_seen_at)>(
 				$"SELECT blk_height, tx_id, wu.idx, value, script, {addrColumns}, {descriptorColumns}, mempool, input_mempool, seen_at " +
 				$"FROM wallets_utxos wu{descriptorJoin} WHERE code=@code AND wallet_id=@walletId AND immature IS FALSE AND value > 546" +
-				$"ORDER BY {CoinSelectionHelpers.OrderBy(strategy, Math.Truncate((double)(amount / limit)))}", new { code = network.CryptoCode, walletId = repo.GetWalletKey(trackedSource).wid }));
+				$"ORDER BY {CoinSelectionHelpers.OrderBy(strategy, closestTo ?? Math.Truncate((double)(amount / limit)))}", new { code = network.CryptoCode, walletId = repo.GetWalletKey(trackedSource).wid }));
 			UTXOChanges changes = new UTXOChanges()
 			{
 				CurrentHeight = (int)height,

--- a/NBXplorer/Controllers/CoinSelectionController.cs
+++ b/NBXplorer/Controllers/CoinSelectionController.cs
@@ -1,0 +1,129 @@
+using Dapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using NBitcoin;
+using NBXplorer.Backends;
+using NBXplorer.Backends.Postgres;
+using NBXplorer.DerivationStrategy;
+using NBXplorer.ModelBinders;
+using NBXplorer.Models;
+using System;
+using System.Threading.Tasks;
+
+namespace NBXplorer.Controllers
+{
+	[Route("v1")]
+	[Authorize]
+	public class CoinSelectionController : ControllerBase
+	{
+		public CoinSelectionController(
+			DbConnectionFactory connectionFactory,
+			NBXplorerNetworkProvider networkProvider,
+			IRPCClients rpcClients,
+			IIndexers indexers,
+			IRepositoryProvider repositoryProvider) : base(networkProvider, rpcClients, repositoryProvider, indexers)
+		{
+			ConnectionFactory = connectionFactory;
+		}
+
+		private DbConnectionFactory ConnectionFactory { get; }
+
+		[HttpGet]
+		[Route("cryptos/{cryptoCode}/derivations/{derivationScheme}/selectutxos")]
+		[Route("cryptos/{cryptoCode}/addresses/{address}/selectutxos")]
+		[PostgresImplementationActionConstraint(true)]
+		public async Task<IActionResult> GetUTXOsByLimit(
+			string cryptoCode,
+			[ModelBinder(BinderType = typeof(DerivationStrategyModelBinder))]
+			DerivationStrategyBase derivationScheme,
+			[ModelBinder(BinderType = typeof(BitcoinAddressModelBinder))]
+			BitcoinAddress address,
+			[FromQuery(Name = "amount")] long amount,
+			[FromQuery(Name = "limit")] int limit = 50,
+			[FromQuery(Name = "tolerance")] int tolerance = 0,
+			[FromQuery(Name = "strategy")] CoinSelectionStrategy strategy = CoinSelectionStrategy.SmallestFirst)
+		{
+			var trackedSource = GetTrackedSource(derivationScheme, address);
+			if (trackedSource == null)
+				throw new ArgumentNullException(nameof(trackedSource));
+			var network = GetNetwork(cryptoCode, false);
+			var repo = (PostgresRepository)RepositoryProvider.GetRepository(cryptoCode);
+
+			await using var conn = await ConnectionFactory.CreateConnection();
+			var height = await conn.ExecuteScalarAsync<long>("SELECT height FROM get_tip(@code)", new { code = network.CryptoCode });
+
+
+			// On elements, we can't get blinded address from the scriptPubKey, so we need to fetch it rather than compute it
+			string addrColumns = "NULL as address";
+			if (network.IsElement && !derivationScheme.Unblinded())
+			{
+				addrColumns = "ds.metadata->>'blindedAddress' as address";
+			}
+
+			string descriptorJoin = string.Empty;
+			string descriptorColumns = "NULL as redeem, NULL as keypath, NULL as feature";
+			if (derivationScheme is not null)
+			{
+				descriptorJoin = " JOIN descriptors_scripts ds USING (code, script) JOIN descriptors d USING (code, descriptor)";
+				descriptorColumns = "ds.metadata->>'redeem' redeem, nbxv1_get_keypath(d.metadata, ds.idx) AS keypath, d.metadata->>'feature' feature";
+			}
+
+			var utxos = (await conn.QueryAsync<(
+				long? blk_height,
+				string tx_id,
+				int idx,
+				long value,
+				string script,
+				string address,
+				string redeem,
+				string keypath,
+				string feature,
+				bool mempool,
+				bool input_mempool,
+				DateTime tx_seen_at)>(
+				$"SELECT blk_height, tx_id, wu.idx, value, script, {addrColumns}, {descriptorColumns}, mempool, input_mempool, seen_at " +
+				$"FROM wallets_utxos wu{descriptorJoin} WHERE code=@code AND wallet_id=@walletId AND immature IS FALSE AND value > 546" +
+				$"ORDER BY {CoinSelectionHelpers.OrderBy(strategy, Math.Truncate((double)(amount / limit)))}", new { code = network.CryptoCode, walletId = repo.GetWalletKey(trackedSource).wid }));
+			UTXOChanges changes = new UTXOChanges()
+			{
+				CurrentHeight = (int)height,
+				TrackedSource = trackedSource,
+				DerivationStrategy = derivationScheme
+			};
+			foreach (var utxo in utxos)
+			{
+				var u = new UTXO()
+				{
+					Index = utxo.idx,
+					Timestamp = new DateTimeOffset(utxo.tx_seen_at),
+					Value = Money.Satoshis(utxo.value),
+					ScriptPubKey = Script.FromHex(utxo.script),
+					Redeem = utxo.redeem is null ? null : Script.FromHex(utxo.redeem),
+					TransactionHash = uint256.Parse(utxo.tx_id)
+				};
+				u.Outpoint = new OutPoint(u.TransactionHash, u.Index);
+				if (utxo.blk_height is long)
+				{
+					u.Confirmations = (int)(height - utxo.blk_height + 1);
+				}
+
+				if (utxo.keypath is not null)
+				{
+					u.KeyPath = KeyPath.Parse(utxo.keypath);
+					u.Feature = Enum.Parse<DerivationFeature>(utxo.feature);
+				}
+				u.Address = utxo.address is null ? u.ScriptPubKey.GetDestinationAddress(network.NBitcoinNetwork) : BitcoinAddress.Create(utxo.address, network.NBitcoinNetwork);
+				if (!utxo.mempool)
+					changes.Confirmed.UTXOs.Add(u);
+				else if (!utxo.input_mempool)
+					changes.Unconfirmed.UTXOs.Add(u);
+				if (utxo.input_mempool && !utxo.mempool)
+					changes.Unconfirmed.SpentOutpoints.Add(u.Outpoint);
+			}
+
+			changes.Confirmed.UTXOs = CoinSelectionHelpers.SelectCoins(changes.Confirmed.UTXOs, limit, amount, tolerance);
+			changes.Unconfirmed.UTXOs = CoinSelectionHelpers.SelectCoins(changes.Unconfirmed.UTXOs, limit, amount, tolerance);
+			return Json(changes, network.JsonSerializerSettings);
+		}
+	}
+}

--- a/NBXplorer/Controllers/CoinSelectionController.cs
+++ b/NBXplorer/Controllers/CoinSelectionController.cs
@@ -39,9 +39,9 @@ namespace NBXplorer.Controllers
 			[ModelBinder(BinderType = typeof(BitcoinAddressModelBinder))]
 			BitcoinAddress address,
 			[FromQuery(Name = "amount")] long amount,
-			[FromQuery(Name = "limit")] int limit = 50,
+			[FromQuery(Name = "limit")] int limit = 0,
 			[FromQuery(Name = "tolerance")] int tolerance = 0,
-			[FromQuery(Name = "closestTo")] double? closestTo = null,
+			[FromQuery(Name = "closestTo")] long? closestTo = null,
 			[FromQuery(Name = "strategy")] CoinSelectionStrategy strategy = CoinSelectionStrategy.SmallestFirst)
 		{
 			var trackedSource = GetTrackedSource(derivationScheme, address);
@@ -84,7 +84,7 @@ namespace NBXplorer.Controllers
 				DateTime tx_seen_at)>(
 				$"SELECT blk_height, tx_id, wu.idx, value, script, {addrColumns}, {descriptorColumns}, mempool, input_mempool, seen_at " +
 				$"FROM wallets_utxos wu{descriptorJoin} WHERE code=@code AND wallet_id=@walletId AND immature IS FALSE AND value > 546" +
-				$"ORDER BY {CoinSelectionHelpers.OrderBy(strategy, closestTo ?? Math.Truncate((double)(amount / limit)))}", new { code = network.CryptoCode, walletId = repo.GetWalletKey(trackedSource).wid }));
+				$"ORDER BY {CoinSelectionHelpers.OrderBy(strategy, closestTo ?? 0)}", new { code = network.CryptoCode, walletId = repo.GetWalletKey(trackedSource).wid }));
 			UTXOChanges changes = new UTXOChanges()
 			{
 				CurrentHeight = (int)height,

--- a/NBXplorer/Properties/launchSettings.json
+++ b/NBXplorer/Properties/launchSettings.json
@@ -24,6 +24,25 @@
       "applicationUrl": "http://localhost:4774",
       "launchUrl": "v1/cryptos/ltc/status"
     },
+
+    "NBXplorer - Elenpay Dev": {
+      "commandName": "Project",
+      "commandLineArgs": "--chains=btc --network=regtest",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "NBXPLORER_EXPOSERPC": "true",
+        "NBXPLORER_POSTGRES": "User ID=postgres;Host=localhost;Port=35432;Database=nbxplorer",
+        "NBXPLORER_BTCRPCUSER": "polaruser",
+        "NBXPLORER_BTCRPCPASSWORD": "polarpass",
+        "NBXPLORER_BTCRPCURL": "http://localhost:18443/",
+        "NBXPLORER_BTCNODEENDPOINT": "127.0.0.1:19444",
+        "NBXPLORER_BIND": "localhost:12838",
+        "NBXPLORER_NOAUTH": 1
+      },
+      "applicationUrl": "http://localhost:4774"
+    },
+
     "NBXplorer - BTC & LBTC on Regtest from Docker": {
       "commandName": "Project",
       "launchBrowser": true,


### PR DESCRIPTION
The logic is that you get the limit amount of utxos first, and then if you don't reach the amount needed, you backtrack and replace smaller amount utxos with bigger amount utxos.

- You can select the maximum limit of utxos you want to use
- You can select a tolerance above and below if you want to do a changeless transaction
- You can order the utxos by ascending value, descending value, and then if the user wants utxos from fairly the same size, you can get them closest to a specific target number